### PR TITLE
Remove unused import from training notebook

### DIFF
--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -7,7 +7,6 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import numpy as np\n",
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.preprocessing import StandardScaler\n",
     "from sklearn.ensemble import RandomForestClassifier\n",


### PR DESCRIPTION
## Summary
- clean up `training.ipynb` by dropping the unused `numpy` import

## Testing
- `nbstripout notebooks/training.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_6845700c721c8320a1d704f385909562